### PR TITLE
Sparse ELLPACK

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,29 @@ Release History
 2.1.1 (unreleased)
 ==================
 
+*Compatible with Nengo 3.1.0*
+
+**Added**
+
+- The benchmarks in the ``examples`` folder now have nicer command-line interfaces.
+  Use the ``--help`` flag with any benchmark to learn more about the options. (`#187`_)
+- The new ``examples/benchmark_backends.py`` script makes it easier to compare between
+  different backends on any of the benchmarks. (`#187`_)
+
+**Changed**
+
+- Sparse matrix multiplication is now faster in many cases by using the ELLPACK matrix
+  format. It uses more memory for some sparse matrices, though; for matrices where it
+  would result in a large increase in memory usage, we fall back on the old CSR format.
+  To force a particular format, set the ``NENGO_OCL_SPMV_ALGORITHM`` environment
+  variable to either "ELLPACK" or "CSR". (`#188`_)
+
+**Removed**
+
+- Dropped support for Python 3.5. (`#187`_)
+
+.. _#187: https://github.com/nengo-labs/nengo-ocl/pull/187
+.. _#188: https://github.com/nengo-labs/nengo-ocl/pull/188
 
 2.1.0 (Nov 23, 2020)
 ====================

--- a/nengo_ocl/simulator.py
+++ b/nengo_ocl/simulator.py
@@ -58,7 +58,7 @@ from nengo_ocl.operators import MultiDotInc, simplify_operators
 from nengo_ocl.plan import BasePlan, Plans, PythonPlan
 from nengo_ocl.planners import greedy_planner
 from nengo_ocl.raggedarray import RaggedArray
-from nengo_ocl.utils import get_closures, indent, split, stable_unique
+from nengo_ocl.utils import HostSparseMatrix, get_closures, indent, split, stable_unique
 from nengo_ocl.version import (
     bad_nengo_versions,
     latest_nengo_version,
@@ -320,17 +320,9 @@ class Simulator:
             del view_builder
 
             # --- set up sparse data
-            spmatrix = None if scipy_sparse is None else scipy_sparse.spmatrix
-            sparse_data = [sigdict[sb] for sb in sparse_bases]
-            if spmatrix is None and len(sparse_data) > 0:
-                raise NotImplementedError("Sparse matrices not supported without Scipy")
-            elif not all(isinstance(x, spmatrix) for x in sparse_data):
-                raise NotImplementedError(
-                    "All sparse matrices must be instances of `scipy.sparse.spmatrix`"
-                )
-
             sparse_sidx_map = {b: i for i, b in enumerate(sparse_bases)}
             self.sparse_sidx = {s: np.int32(sparse_sidx_map[s]) for s in sparse_signals}
+            sparse_data = [HostSparseMatrix(sigdict[sb]) for sb in sparse_bases]
 
             # Copy data to device
             self.all_data = CLRaggedArray(self.queue, dense_data)

--- a/nengo_ocl/simulator.py
+++ b/nengo_ocl/simulator.py
@@ -883,20 +883,19 @@ class Simulator:
         return [plan_elementwise_inc(self.queue, A, X, Y)]
 
     def _plan_SparseDotInc(self, ops):
+        """Sparse MV algorithm is simulation-wide and can be controlled
+        by setting configuration variable "NENGO_OCL_SPMV_ALGORITHM"
+        """
         assert scipy_sparse is not None
 
         # currently gives one plan per sparse operation instead of combining them all
         plans = []
         for op in ops:
-            A = self.sparse_data[self.sparse_sidx[op.A]].tocsr()
-            A_indices = self.Array(A.indices, dtype=np.int32)
-            A_indptr = self.Array(A.indptr, dtype=np.int32)
-            A_data = self.Array(A.data)
+            A = self.sparse_data[self.sparse_sidx[op.A]]
             X = self.all_data[[self.sidx[op.X]]]
             Y = self.all_data[[self.sidx[op.Y]]]
-            plans.append(
-                plan_sparse_dot_inc(self.queue, A_indices, A_indptr, A_data, X, Y)
-            )
+            rval = plan_sparse_dot_inc(self.queue, A, X, Y)
+            plans += rval.plans
 
         return plans
 

--- a/nengo_ocl/tests/test_clra_gemv.py
+++ b/nengo_ocl/tests/test_clra_gemv.py
@@ -12,8 +12,6 @@ from nengo_ocl.clra_gemv import (
     plan_block_gemv,
     plan_csr,
     plan_ellpack,
-    plan_ellpack_nonlocal,
-    plan_ellpack_serial,
     plan_ellpack_tree,
     plan_many_dots_gemv,
     plan_ragged_gather_gemv,
@@ -43,9 +41,7 @@ def pytest_generate_tests(metafunc):
             [
                 plan_ellpack,
                 # plan_ellpack_twostep,
-                # plan_ellpack_nonlocal,
                 # plan_ellpack_tree,
-                # plan_ellpack_serial,
                 plan_csr,
             ],
         )
@@ -441,9 +437,7 @@ def test_sparse(sparse_planner, inc, long_row, sparsity, shape, ctx, rng, allclo
     # -- check for anticipated failures
     max_row_len = np.diff(A.tocsr().indptr).max()
 
-    if sparse_planner in [plan_ellpack_serial, plan_ellpack_tree] and (
-        max_row_len > max_wgs
-    ):
+    if sparse_planner is plan_ellpack_tree and max_row_len > max_wgs:
         with pytest.raises(ValueError, match="work group size"):
             sparse_planner(queue, A, clX, clY, inc=inc)
 

--- a/nengo_ocl/tests/test_clra_gemv.py
+++ b/nengo_ocl/tests/test_clra_gemv.py
@@ -20,6 +20,7 @@ from nengo_ocl.clra_gemv import (
 )
 from nengo_ocl.clraggedarray import CLRaggedArray as CLRA
 from nengo_ocl.raggedarray import RaggedArray
+from nengo_ocl.utils import HostSparseMatrix
 
 logger = logging.getLogger(__name__)
 RA = lambda arrays, dtype=np.float32: RaggedArray(arrays, dtype=dtype)
@@ -460,6 +461,7 @@ def test_sparse(sparse_planner, inc, long_row, sparsity, shape, ctx, rng, allclo
         assert allclose(ref, sim, atol=1e-6)
 
 
+@pytest.mark.filterwarnings("ignore:Changing the sparsity structure of a csr_matrix")
 def test_spmv_impl_heuristic(ctx):
     scipy_sparse = pytest.importorskip("scipy.sparse")
 
@@ -483,7 +485,8 @@ def test_spmv_impl_heuristic(ctx):
         (A_bad_for_ELL, "CSR"),
         (A_small, "ELLPACK"),
     ]:
+        hA = HostSparseMatrix(A)
         assert (
-            spmv_algorithm_heuristic(queue, A, footprint_soft_limit=testing_limit)
+            spmv_algorithm_heuristic(queue, hA, footprint_soft_limit=testing_limit)
             == answer
         )

--- a/nengo_ocl/utils.py
+++ b/nengo_ocl/utils.py
@@ -8,6 +8,7 @@ import warnings
 import nengo
 import numpy as np
 import pyopencl as cl
+from nengo.utils.numpy import scipy_sparse
 
 import nengo_ocl
 
@@ -77,6 +78,32 @@ def stable_unique(seq):
             seen.add(item)
             rval.append(item)
     return rval
+
+
+class HostSparseMatrix:
+    """Represents a sparse matrix on the host in a variety of formats."""
+
+    def __init__(self, spmatrix):
+        scipy_spmatrix = None if scipy_sparse is None else scipy_sparse.spmatrix
+        if scipy_spmatrix is None:
+            raise NotImplementedError("Sparse matrices not supported without Scipy")
+        elif not isinstance(spmatrix, (np.ndarray, scipy_spmatrix)):
+            raise NotImplementedError(
+                "Sparse matrices must be instances of `scipy.sparse.spmatrix`"
+            )
+
+        self.matrix = spmatrix
+        self.clear_cache()
+
+    def clear_cache(self):
+        self._csr = None
+
+    @property
+    def csr(self):
+        if self._csr is None:
+            self._csr = scipy_sparse.csr_matrix(self.matrix)
+
+        return self._csr
 
 
 class SimRunner:


### PR DESCRIPTION
**Motivation and context:**
Performance improvement to sparse matrix vector multiplications. See #186 for background and initial benchmarking. This PR completes the TODO list mentioned in that issue.

Depends on #187 being merged first.

**How long should this take to review?**
- Moderate/lengthy. There are a lot of lines added, but it is tested pretty well. I rewrote history in attempts to make it easier to review.

**Where should a reviewer start?**
Run the tests. 

Commits reflect the logical progress of the different features if you want to follow along,
1. "working serial ELLPACK" is the data storage format and reference implementation
2. "working tree-based reduction" is the most basic performant algorithm. It is now the default implementation, but does not work for more than 1024 fan-in per neuron
3. "two kernel big ELLPACK" has the algorithm that works up to 1M fan-in per neuron
4. "spmv_prog style" is the new planner interface, selecting algorithms, determining device storage formats, etc.

**Questions for devs**
- should `clra_spmv.py` be its own file?
- does the `spmv_prog` class make sense? I tried to follow the patterns used in `gemv_prog` and the gemv `_impl`s
- There are other ELLPACK implementations "serial" and "nonlocal" that could be cut. The regular user will only ever use the best one.